### PR TITLE
Removes byebug require from api_operations/download

### DIFF
--- a/lib/nfe/api_operations/download.rb
+++ b/lib/nfe/api_operations/download.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 module Nfe
   module ApiOperations
     module Download


### PR DESCRIPTION
After implement download options I forgot to remove the require of "byebug" from download module.